### PR TITLE
rework for new __raw endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # iman: illumos man page viewer
 
 iman is a tiny script for viewing illumos man pages from OS X.  Man pages are
-fetched from http://illumos.org/man.  By default, iman looks for the "links"
-browser and uses that to render the page.  If "links" isn't found, it uses
-"open" to open the URL in your default browser.
+fetched from http://illumos.org/man.  By default, iman uses `curl` to fetch
+the page, piping the text to `more` (or `$PAGER`).  The `open` command may
+optionally be used to open the URL in your default browser.
 
-**iman [-s SECTION] NAME**
+**`iman [-o] [-s SECTION] NAME`**
 
 Use `iman` like man, except that only the "-s" option is supported.
 
@@ -17,4 +17,9 @@ Specify section 2 (system calls) instead:
 
     iman -s2 read
 
-Thanks to Josh Clulow for the illumos.org man page viewer.
+Use the "-o" flag to open the page in a browser:
+
+    iman -o -s1M dladm
+
+Thanks to [Joshua M. Clulow](https://twitter.com/jmclulow) for the illumos.org
+[man page viewer](https://github.com/jclulow/illumos-webman).

--- a/iman
+++ b/iman
@@ -15,15 +15,12 @@ function usage
 
 base="http://illumos.org/man"
 url="$base"
-uselinks="true"
+useopen="false"
 
-if ! type "links" > /dev/null 2>&1; then
-	uselinks="false"
-fi
-
-while getopts ":s:" c "$@"; do
+while getopts ":s:o" c "$@"; do
 	case "$c" in
 	s)	url="$base/$OPTARG" ;;
+	o)	useopen="true" ;;
 	:)      usage "option requires an argument -- $OPTARG"  ;;
 	*)      usage "invalid option -- $OPTARG"  ;;
 	esac
@@ -33,8 +30,8 @@ shift $(( $OPTIND - 1))
 [[ -n "$1" ]] || usage
 echo "$url/$1"
 
-if [[ $uselinks == "true" ]]; then
-	links -dump "$url/$1" | ${PAGER:-more}
+if [[ $useopen != "true" ]]; then
+	curl -s "$url/__raw/$1" | ${PAGER:-more}
 else
 	open "$url/$1"
 fi


### PR DESCRIPTION
Rather than use `links`, which can be a bit sub-par, we instead can use `curl` to fetch the raw output from `mandoc` without any intermediate HTML chicanery.
